### PR TITLE
#20 - perf : 게시글 post시 board_id를 서버에서 자동을 지정하도록 수정

### DIFF
--- a/project/enjoyTrip/src/main/resources/mapper/answer.xml
+++ b/project/enjoyTrip/src/main/resources/mapper/answer.xml
@@ -27,7 +27,7 @@
         insert into answers
             (question_id, board_id, user_no, answer_title, answer_content, answer_post_date)
         values
-            (#{questionId}, #{boardId}, #{userNo}, #{answerTitle}, #{answerContent}, now());
+            (#{questionId}, 5, #{userNo}, #{answerTitle}, #{answerContent}, now());
     </insert>
 
     <update id="modifyAnswer" parameterType="answerDto">

--- a/project/enjoyTrip/src/main/resources/mapper/notice.xml
+++ b/project/enjoyTrip/src/main/resources/mapper/notice.xml
@@ -17,7 +17,7 @@
         insert
         into notices
         (board_id, user_no, notice_title, notice_content, notice_post_date)
-        values (#{boardId},#{userNo},#{noticeTitle},#{noticeContent}, now())
+        values (1,#{userNo},#{noticeTitle},#{noticeContent}, now())
     </insert>
 
     <select id="getNoticeList" resultMap="notice">

--- a/project/enjoyTrip/src/main/resources/mapper/question.xml
+++ b/project/enjoyTrip/src/main/resources/mapper/question.xml
@@ -29,7 +29,7 @@
     <insert id="postQuestion" parameterType="questionDto">
         insert into questions
         (board_id, user_no, question_title, question_content, question_post_date, question_secret)
-        values (#{boardId}, #{userNo}, #{questionTitle}, #{questionContent}, now(), #{questionSecret});
+        values (4, #{userNo}, #{questionTitle}, #{questionContent}, now(), #{questionSecret});
     </insert>
 
     <update id="modifyQuestion" parameterType="questionDto">

--- a/project/enjoyTrip/target/classes/mapper/answer.xml
+++ b/project/enjoyTrip/target/classes/mapper/answer.xml
@@ -27,7 +27,7 @@
         insert into answers
             (question_id, board_id, user_no, answer_title, answer_content, answer_post_date)
         values
-            (#{questionId}, #{boardId}, #{userNo}, #{answerTitle}, #{answerContent}, now());
+            (#{questionId}, 5, #{userNo}, #{answerTitle}, #{answerContent}, now());
     </insert>
 
     <update id="modifyAnswer" parameterType="answerDto">

--- a/project/enjoyTrip/target/classes/mapper/notice.xml
+++ b/project/enjoyTrip/target/classes/mapper/notice.xml
@@ -17,7 +17,7 @@
         insert
         into notices
         (board_id, user_no, notice_title, notice_content, notice_post_date)
-        values (#{boardId},#{userNo},#{noticeTitle},#{noticeContent}, now())
+        values (1,#{userNo},#{noticeTitle},#{noticeContent}, now())
     </insert>
 
     <select id="getNoticeList" resultMap="notice">

--- a/project/enjoyTrip/target/classes/mapper/question.xml
+++ b/project/enjoyTrip/target/classes/mapper/question.xml
@@ -29,7 +29,7 @@
     <insert id="postQuestion" parameterType="questionDto">
         insert into questions
         (board_id, user_no, question_title, question_content, question_post_date, question_secret)
-        values (#{boardId}, #{userNo}, #{questionTitle}, #{questionContent}, now(), #{questionSecret});
+        values (4, #{userNo}, #{questionTitle}, #{questionContent}, now(), #{questionSecret});
     </insert>
 
     <update id="modifyQuestion" parameterType="questionDto">


### PR DESCRIPTION
게시글 post시 json 인자값 중 하나로 받아오던 board_id를 서버에서 자동을 지정하도록 수정.
게시글 작성시 json 데이터에 board_id가 필요하지 않도록 변경